### PR TITLE
WIP: prefix the pathPrefix

### DIFF
--- a/data/SiteConfig.js
+++ b/data/SiteConfig.js
@@ -7,7 +7,7 @@ module.exports = {
   siteLogo:
     "https://haysclark.github.io/gatsby-starter-casper/logos/logo-1024.png", // Logo used for SEO and manifest. e.g. "/logos/logo-1024.png",
   siteUrl: "https://www.ryankilleen.com", // Domain of your website without pathPrefix.
-  pathPrefix: "", // Prefixes all links. For cases when deployed to example.github.io/gatsby-starter-casper/.
+  pathPrefix: "/", // Prefixes all links. For cases when deployed to example.github.io/gatsby-starter-casper/.
   siteDescription:
     "A UI Developer's musing on web engineering, working together, technology, and getting through the day.", // Website description used for RSS feeds/meta description tag.
   siteCover:

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -5,13 +5,13 @@ const pathPrefix = config.pathPrefix === "/" ? "" : config.pathPrefix;
 module.exports = {
   pathPrefix: config.pathPrefix,
   siteMetadata: {
-    siteUrl: config.siteUrl + pathPrefix,
+    siteUrl: config.siteUrl + config.pathPrefix,
     rssMetadata: {
-      site_url: config.siteUrl + pathPrefix,
-      feed_url: config.siteUrl + pathPrefix + config.siteRss,
+      site_url: config.siteUrl + config.pathPrefix,
+      feed_url: config.siteUrl + config.pathPrefix + config.siteRss,
       title: config.siteTitle,
       description: config.siteDescription,
-      image_url: `${config.siteUrl + pathPrefix}/logos/logo-512.png`,
+      image_url: `${config.siteUrl + config.pathPrefix}/logos/logo-512.png`,
       author: config.siteRssAuthor,
       copyright: `${config.copyright.label} © ${config.copyright.year ||
         new Date().getFullYear()}`

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,6 +1,6 @@
 const config = require("./data/SiteConfig");
 
-const constPathPrefix = config.pathPrefix === "/" ? "" : config.pathPrefix;
+const constPathPrefix = config.pathPrefix === "" ? "/" : config.pathPrefix;
 
 module.exports = {
   pathPrefix: constPathPrefix,

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,17 +1,17 @@
 const config = require("./data/SiteConfig");
 
-const pathPrefix = config.pathPrefix === "/" ? "" : config.pathPrefix;
+const constPathPrefix = config.pathPrefix === "/" ? "" : config.pathPrefix;
 
 module.exports = {
-  pathPrefix: config.pathPrefix,
+  pathPrefix: constPathPrefix,
   siteMetadata: {
-    siteUrl: config.siteUrl + config.pathPrefix,
+    siteUrl: config.siteUrl + constPathPrefix,
     rssMetadata: {
-      site_url: config.siteUrl + config.pathPrefix,
-      feed_url: config.siteUrl + config.pathPrefix + config.siteRss,
+      site_url: config.siteUrl + constPathPrefix,
+      feed_url: config.siteUrl + constPathPrefix + config.siteRss,
       title: config.siteTitle,
       description: config.siteDescription,
-      image_url: `${config.siteUrl + config.pathPrefix}/logos/logo-512.png`,
+      image_url: `${config.siteUrl + constPathPrefix}/logos/logo-512.png`,
       author: config.siteRssAuthor,
       copyright: `${config.copyright.label} © ${config.copyright.year ||
         new Date().getFullYear()}`
@@ -75,7 +75,7 @@ module.exports = {
         name: config.siteTitle,
         short_name: config.siteTitle,
         description: config.siteDescription,
-        start_url: config.pathPrefix,
+        start_url: constPathPrefix,
         background_color: config.backgroundColor,
         theme_color: config.themeColor,
         display: "minimal-ui",


### PR DESCRIPTION
Resolves #11.

It appeared that pathPrefix was set but then other structures may have been referring to `pathPrefix` when they could benefit from referring to `config.pathPrefix`. 